### PR TITLE
Bugix in _format_sql_cell in handling # MAGIC %sql

### DIFF
--- a/blackbricks/blackbricks.py
+++ b/blackbricks/blackbricks.py
@@ -95,14 +95,17 @@ def _format_sql_cell(
     if NOFMT in cell.strip().splitlines()[0]:
         return title_line + cell
 
-    magics = []
     sql_lines = []
     for line in cell.strip().splitlines():
         if line.strip().startswith("# MAGIC %sql"):
-            continue
+            if line.strip().endswith("# MAGIC %sql"):
+                continue
+            else:
+                sql = line.strip().replace("# MAGIC %sql", "")
+                sql_lines.append(sql.strip())
+                continue
         words = line.split()
         magic, sql = words[:2], words[2:]
-        magics.append(magic)
         sql_lines.append(" ".join(sql).strip())
 
     return (
@@ -111,7 +114,7 @@ def _format_sql_cell(
         + "\n".join(
             f"# MAGIC {sql}"
             for sql in sqlparse.format(
-                "\n".join(sql_lines), reindent=True, keyword_case=sql_keyword_case
+                "\n" + "\n".join(sql_lines), reindent=True, keyword_case=sql_keyword_case
             ).splitlines()
         )
     )

--- a/test_notebooks/test.py
+++ b/test_notebooks/test.py
@@ -72,3 +72,34 @@ def test_func(input_param):
 # MAGIC           FIRST(bar.baz)
 # MAGIC    FROM dsa.asd bar
 # MAGIC    GROUP BY bar.fizzbuzz);
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC 
+# MAGIC 
+# MAGIC SELECT id from test_table LIMIT 1
+# MAGIC -- 3 NewLines after %sql
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC 
+# MAGIC SELECT id from test_table LIMIT 1
+# MAGIC -- 2 NewLines after %sql
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC SELECT id from test_table LIMIT 1
+# MAGIC -- 1 NewLines after %sql
+
+# COMMAND ----------
+
+# MAGIC %sql SELECT id from test_table LIMIT 1
+# MAGIC -- SPACE after %sql
+
+# COMMAND ----------
+
+# MAGIC %sql	SELECT id from test_table LIMIT 1
+# MAGIC -- TAB after %sql


### PR DESCRIPTION
This bugfix fixes the issue when %sql is not on a separate line.

**Change of source code:**

OLD:
- Resulting SQL cell is wrong, when %sql is not on a separate line
  - %sql is followed by SPACE/TAB + "first line of the SQL query"
  - Example:
    - %sql SELECT current_date
- Sometimes an additional (empty) line is added after %sql. But not always!
OLD:
- Resulting SQL cell is correct, when %sql is not on a separate line
  - Example:
    - %sql SELECT current_date
  - it doesn't matter if a SPACE or TAB follows %sql
- exactly 1 additional (empty) line is added after %sql. Always!
- in addition the list magics[] has been removed from the code. It's not used.

**Test cases adapted:**

Added test cases to test some weird cases, when:
- MAGIC %sql is not on a separate line (Databricks allows this)
- MAGIC %sql is followed by 0/1/multiple NewLines

The result has to be deterministic always:
- If Databricks accepts (the first line of) the SQL query behind "# MAGIC %sql", we have to accept this too!
- It doesn't matter if %sql is followed by:
  - SPACE
  - TAB
  - exactly 1 NewLine
  - multiple NewLines
...
The result has to be deterministic!
 - 1st line: # MAGIC %sql
 - 2nd line: # 
 - 3rd line: # First-line-of-sqlparse-Output
 - ...

Signed-off-by: Dejan.Hrubenja <dejan.hrubenja@mercedes-benz.com>